### PR TITLE
Change set_priority() -> update_priority() noexcept

### DIFF
--- a/apf/jack_policy.h
+++ b/apf/jack_policy.h
@@ -123,7 +123,7 @@ struct thread_traits;  // definition in mimoprocessor.h
 template<>
 struct thread_traits<jack_policy, pthread_t>
 {
-  static void set_priority(const jack_policy& obj, pthread_t thread_id)
+  static void update_priority(const jack_policy& obj, pthread_t thread_id) noexcept
   {
     if (obj.is_realtime())
     {
@@ -131,7 +131,11 @@ struct thread_traits<jack_policy, pthread_t>
       param.sched_priority = obj.get_real_time_priority();
       if (pthread_setschedparam(thread_id, SCHED_FIFO, &param))
       {
-        throw std::runtime_error("Can't set scheduling priority for thread!");
+        // We were trying our best to set the priority, but if it doesn't work,
+        // the show must go on!
+#ifdef APF_JACK_POLICY_DEBUG
+        printf("Can't set scheduling priority %d for thread!\n", param.sched_priority);
+#endif
       }
     }
     else

--- a/apf/mimoprocessor.h
+++ b/apf/mimoprocessor.h
@@ -78,7 +78,7 @@ namespace apf
 template<typename interface_policy, typename native_handle_type>
 struct thread_traits
 {
-  static void set_priority(const interface_policy&, native_handle_type) {}
+  static void update_priority(const interface_policy&, native_handle_type) noexcept {}
 };
 
 class enable_queries
@@ -371,7 +371,7 @@ class MimoProcessor : public interface_policy
         {
           // Set thread priority from interface_policy, if available
           thread_traits<interface_policy
-            , std::thread::native_handle_type>::set_priority(parent
+            , std::thread::native_handle_type>::update_priority(parent
                 , _thread.native_handle());
         }
 


### PR DESCRIPTION
It looks like on Windows `pthread_setschedparam()` may not be successful.

With this PR, we allow the function call to fail and simply continue.

Obsoletes and closes #18.